### PR TITLE
Allowing GCP provisioner to issue SSH User Certificates - Option 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get up and running quickly, or as an alternative to running your own `step-ca
 [Documentation](https://smallstep.com/docs) |
 [Installation](https://smallstep.com/docs/step-ca/installation) |
 [Getting Started](https://smallstep.com/docs/step-ca/getting-started) |
-[Contributor's Guide](./docs/CONTRIBUTING.md)
+[Contributor's Guide](./CONTRIBUTING.md)
 
 [![GitHub release](https://img.shields.io/github/release/smallstep/certificates.svg)](https://github.com/smallstep/certificates/releases/latest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/smallstep/certificates)](https://goreportcard.com/report/github.com/smallstep/certificates)

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -289,6 +289,7 @@ func SSHSign(w http.ResponseWriter, r *http.Request) {
 
 	ctx := provisioner.NewContextWithMethod(r.Context(), provisioner.SSHSignMethod)
 	ctx = provisioner.NewContextWithToken(ctx, body.OTT)
+	ctx = provisioner.NewContextWithCertType(ctx, opts.CertType)
 
 	a := mustAuthority(ctx)
 	signOpts, err := a.Authorize(ctx, body.OTT)

--- a/authority/provisioner/gcp_test.go
+++ b/authority/provisioner/gcp_test.go
@@ -646,6 +646,10 @@ func TestGCP_AuthorizeSSHSign(t *testing.T) {
 		CertType: "host", Principals: []string{"foo.bar", "bar.foo"},
 		ValidAfter: NewTimeDuration(tm), ValidBefore: NewTimeDuration(tm.Add(hostDuration)),
 	}
+	expectedUserOptions := &SignSSHOptions{
+		CertType: "user", Principals: []string{"foo", "foo@developer.gserviceaccount.com"},
+		ValidAfter: NewTimeDuration(tm), ValidBefore: NewTimeDuration(tm.Add(p1.ctl.Claimer.DefaultUserSSHCertDuration())),
+	}
 
 	type args struct {
 		token   string
@@ -663,14 +667,15 @@ func TestGCP_AuthorizeSSHSign(t *testing.T) {
 	}{
 		{"ok", p1, args{t1, SignSSHOptions{}, pub}, expectedHostOptions, http.StatusOK, false, false},
 		{"ok-rsa2048", p1, args{t1, SignSSHOptions{}, rsa2048.Public()}, expectedHostOptions, http.StatusOK, false, false},
-		{"ok-type", p1, args{t1, SignSSHOptions{CertType: "host"}, pub}, expectedHostOptions, http.StatusOK, false, false},
+		{"ok-type", p1, args{t1, SignSSHOptions{}, pub}, expectedHostOptions, http.StatusOK, false, false},
+		{"ok-type-user", p1, args{t1, SignSSHOptions{CertType: "user"}, pub}, expectedUserOptions, http.StatusOK, false, false},
 		{"ok-principals", p1, args{t1, SignSSHOptions{Principals: []string{"instance-name.c.project-id.internal", "instance-name.zone.c.project-id.internal"}}, pub}, expectedHostOptions, http.StatusOK, false, false},
 		{"ok-principal1", p1, args{t1, SignSSHOptions{Principals: []string{"instance-name.c.project-id.internal"}}, pub}, expectedHostOptionsPrincipal1, http.StatusOK, false, false},
 		{"ok-principal2", p1, args{t1, SignSSHOptions{Principals: []string{"instance-name.zone.c.project-id.internal"}}, pub}, expectedHostOptionsPrincipal2, http.StatusOK, false, false},
 		{"ok-options", p1, args{t1, SignSSHOptions{CertType: "host", Principals: []string{"instance-name.c.project-id.internal", "instance-name.zone.c.project-id.internal"}}, pub}, expectedHostOptions, http.StatusOK, false, false},
 		{"ok-custom", p2, args{t2, SignSSHOptions{Principals: []string{"foo.bar", "bar.foo"}}, pub}, expectedCustomOptions, http.StatusOK, false, false},
 		{"fail-rsa1024", p1, args{t1, SignSSHOptions{}, rsa1024.Public()}, expectedHostOptions, http.StatusOK, false, true},
-		{"fail-type", p1, args{t1, SignSSHOptions{CertType: "user"}, pub}, nil, http.StatusOK, false, true},
+		//{"fail-type", p1, args{t1, SignSSHOptions{CertType: "user"}, pub}, nil, http.StatusOK, false, true},
 		{"fail-principal", p1, args{t1, SignSSHOptions{Principals: []string{"smallstep.com"}}, pub}, nil, http.StatusOK, false, true},
 		{"fail-extra-principal", p1, args{t1, SignSSHOptions{Principals: []string{"instance-name.c.project-id.internal", "instance-name.zone.c.project-id.internal", "smallstep.com"}}, pub}, nil, http.StatusOK, false, true},
 		{"fail-sshCA-disabled", p3, args{"foo", SignSSHOptions{}, pub}, expectedHostOptions, http.StatusUnauthorized, true, false},
@@ -678,7 +683,12 @@ func TestGCP_AuthorizeSSHSign(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.gcp.AuthorizeSSHSign(context.Background(), tt.args.token)
+			ctx := context.Background()
+			if tt.args.sshOpts.CertType == SSHUserCert {
+				ctx = NewContextWithCertType(ctx, SSHUserCert)
+			}
+
+			got, err := tt.gcp.AuthorizeSSHSign(ctx, tt.args.token)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GCP.AuthorizeSSHSign() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/authority/provisioner/method.go
+++ b/authority/provisioner/method.go
@@ -74,3 +74,17 @@ func TokenFromContext(ctx context.Context) (string, bool) {
 	token, ok := ctx.Value(tokenKey{}).(string)
 	return token, ok
 }
+
+// The key to save the certTypeKey in the context.
+type certTypeKey struct{}
+
+// NewContextWithCertType creates a new context with the given CertType.
+func NewContextWithCertType(ctx context.Context, certType string) context.Context {
+	return context.WithValue(ctx, certTypeKey{}, certType)
+}
+
+// CertTypeFromContext returns the certType stored in the given context.
+func CertTypeFromContext(ctx context.Context) (string, bool) {
+	certType, ok := ctx.Value(certTypeKey{}).(string)
+	return certType, ok
+}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Allowing **GCP** provisioner to issue SSH User Certificates - Option 2

#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):

Workloads running in GCP Compute Instances are run with an assigned Service Account. The Service Account authenticated on a given Compute Instance can be found in the Identity Token obtained from the metadata server that the GCP provisioner uses to obtain the Compute Instance identity and generate the SSH Host Certificate.

Allowing the GCP provisioner to issue SSH User Certificates would allow the above referred Workloads to use the smallstep infrastructure to sign into other Compute Instances. Examples of workloads that would benefit from this change are: CICD systems like Jenkins and Ansible.

Without this feature there would be two other options to achieve this:

- Have a separate JWK provisioner: This provisioner is present in the ca.json configuration file.
- Have a X5C provisioner to generate an intermediary X.509 certificate to then issue the SSH User Certificate from it: This option involves the creation of an intermediary certificate that could be used for TLS that will need to be maintained along with the SSH User Certificate.
However neither of these can validate the service account principal.

#### Is there documentation on how to use this feature? If so, where?

If this change is accepted we could update the documentation for the GCP provisioner [here](https://smallstep.com/docs/step-ca/provisioners/#cloud-provisioners)

#### In what environments or workflows is this feature supported?

This would work for smallstep-ca deployments that support GCP

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

This will not work outside of GCP

#### Supporting links/other PRs/issues:

This proposal leverages the use of the Context to find out what kind of certificate is requested because the only arguments available to the `AuthorizeSSHSign` is the context and the id Token (other provisioners that support both host and user certificates get access to an access token that has this information embedded). Because of this there is a significant refactor in the `AuthorizeSSHSign` function but the tests are almost untouched.

We propose a different approach which tries to do the least changes at:

https://github.com/adantop/smallstep-certificates/pull/2

❤️ Thank you!