### PR TITLE
Allowing GCP provisioner to issue SSH User Certificates - Option 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get up and running quickly, or as an alternative to running your own `step-ca
 [Documentation](https://smallstep.com/docs) |
 [Installation](https://smallstep.com/docs/step-ca/installation) |
 [Getting Started](https://smallstep.com/docs/step-ca/getting-started) |
-[Contributor's Guide](./docs/CONTRIBUTING.md)
+[Contributor's Guide](./CONTRIBUTING.md)
 
 [![GitHub release](https://img.shields.io/github/release/smallstep/certificates.svg)](https://github.com/smallstep/certificates/releases/latest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/smallstep/certificates)](https://goreportcard.com/report/github.com/smallstep/certificates)


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Allowing **GCP** provisioner to issue SSH User Certificates - Option 1 

#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):

Workloads running in GCP Compute Instances are run with an assigned Service Account. The Service Account authenticated on a given Compute Instance can be found in the Identity Token obtained from the metadata server that the GCP provisioner uses to obtain the Compute Instance identity and generate the SSH Host Certificate.

Allowing the GCP provisioner to issue SSH User Certificates would allow the above referred Workloads to use the smallstep infrastructure to sign into other Compute Instances. Examples of workloads that would benefit from this change are: CICD systems like Jenkins and Ansible.

Without this feature there would be two other options to achieve this:

- Have a separate JWK provisioner: This provisioner is present in the `ca.json` configuration file.
- Have a X5C provisioner to generate an intermediary X.509 certificate to then issue the SSH User Certificate from it: This option involves the creation of an intermediary certificate that could be used for TLS that will need to be maintained along with the SSH User Certificate.

However neither of these can validate the service account principal.

#### Is there documentation on how to use this feature? If so, where?

If this change is accepted we could update the documentation for the GCP provisioner [here](https://smallstep.com/docs/step-ca/provisioners/#cloud-provisioners)

#### In what environments or workflows is this feature supported?

This would work for smallstep-ca deployments that support GCP

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

This will not work outside of GCP

#### Supporting links/other PRs/issues:

This proposal features minimal changes to the existing code, we removed the enforcement of the `HostCert` type, added the username validation and changed the certificate template. However this change requires a significant refactor to the tests because of the change in the certificate template which leads to rely more on the Certificate Sign Request as opposed to the provisioner sign options.

We propose a second approach which relies the most on the provisioner sign options but required a bigger refactor to the codebase:

https://github.com/adantop/smallstep-certificates/pull/1

❤️ Thank you!
